### PR TITLE
bluegreen: support new version of tsuru API

### DIFF
--- a/src/bluegreen.py
+++ b/src/bluegreen.py
@@ -59,7 +59,7 @@ class BlueGreen:
 
     headers = {"Authorization" : "bearer " + self.token}
     conn = httplib.HTTPConnection(self.target)
-    conn.request("DELETE", "/apps/" + app + '/units', units, headers)
+    conn.request("DELETE", "/apps/" + app + '/units?units='+units, units, headers)
     response = conn.getresponse()
     if response.status != 200:
       print "Error removing units from %s. You'll need to remove manually." % app
@@ -77,7 +77,7 @@ class BlueGreen:
 
     headers = {"Authorization" : "bearer " + self.token}
     conn = httplib.HTTPConnection(self.target)
-    conn.request("PUT", "/apps/" + app + '/units', units, headers)
+    conn.request("PUT", "/apps/" + app + '/units?units='+units, units, headers)
     response = conn.getresponse()
     response.read()
     if response.status != 200:


### PR DESCRIPTION
tsuru-server 0.12.0 changed the API for adding and removing units.
Keeping the amount of units both in the querystring and the body makes
the plugin compatible with the new version, and also keeps it compatible
with the old version.