### PR TITLE
Adds a way to use environment variables in NewRelic's config

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,8 @@ before_swap: <command to run before 'swap' action>
 after_swap: <command to run after a successful 'swap' action>
 ```
 
+**Note:** if a NewRelic key's value is left blank, the plugin will try to get it from an environment variable (`NEW_RELIC_API_KEY` or `NEW_RELIC_APP_ID`).
+
 ### 'Application' section
 
 Based on the `name` configuration value, you must have to have two tsuru applications and git remotes named: your_app**-blue** and your_app**-green**.

--- a/src/bluegreen.py
+++ b/src/bluegreen.py
@@ -369,6 +369,8 @@ class Config:
         newrelic_value = config.get('NewRelic', key)
         if newrelic_value:
           newrelic[key] = newrelic_value
+        else:
+          newrelic[key] = os.getenv('NEW_RELIC_' + key.upper())
 
       except (ConfigParser.NoSectionError, ConfigParser.NoOptionError):
         pass

--- a/test/config_test.py
+++ b/test/config_test.py
@@ -1,3 +1,4 @@
+import os
 import unittest
 from mock import MagicMock
 from mock import Mock
@@ -22,6 +23,17 @@ class TestConfig(unittest.TestCase):
   def test_load_newrelic_config(self):
     self.assertEqual('some-api-key', self.config['newrelic']['api_key'])
     self.assertEqual('123', self.config['newrelic']['app_id'])
+
+  def test_load_newrelic_with_environment_variables(self):
+    os.environ['NEW_RELIC_API_KEY'] = 'api-key-from-environment'
+    os.environ['NEW_RELIC_APP_ID'] = 'app-id-from-environment'
+    self.config = Config.load('test/new-relic-with-blank-values.ini')
+
+    self.assertEqual('api-key-from-environment', self.config['newrelic']['api_key'])
+    self.assertEqual('app-id-from-environment', self.config['newrelic']['app_id'])
+
+    del os.environ['NEW_RELIC_API_KEY']
+    del os.environ['NEW_RELIC_APP_ID']
 
   def test_load_grafana_config(self):
     self.assertEqual('http://tcp.logstash.example.com', self.config['grafana']['endpoint'])

--- a/test/new-relic-with-blank-values.ini
+++ b/test/new-relic-with-blank-values.ini
@@ -1,0 +1,20 @@
+[Application]
+name: app-test
+deploy_dir: '.'
+
+[Hooks]
+before_pre: before_pre.sh
+after_pre:
+after_swap: live.sh
+
+[NewRelic]
+api_key:
+app_id:
+
+[Grafana]
+endpoint: http://tcp.logstash.example.com
+index: test-index
+
+[WebHook]
+endpoint: http://example.com
+payload_extras: key1=value1&key2=value2


### PR DESCRIPTION
Nowadays, in order to configure a deploy notification to NewRelic, an API_KEY must be stored in plain text in a project's tsuru-bluegreen.ini.

This PR introduces a way to configure these stuff with environment variables, since storing secrets in plain text does not seem to be a good practice.

PS: I'm a Python newbie, so feedbacks are welcome!