### PR TITLE
Refactor app swap changing cname

### DIFF
--- a/src/bluegreen.py
+++ b/src/bluegreen.py
@@ -272,7 +272,7 @@ class BlueGreen:
 
     if not self.run_hook('before_pre', {"TAG": tag}):
         print """
-  Error running 'before' hook. Pre deploy aborted.
+  Error running 'before_pre' hook. Pre deploy aborted.
         """
         return 2
 
@@ -291,7 +291,7 @@ class BlueGreen:
 
     if not self.run_hook('after_pre', {"TAG": tag}):
         print """
-  Error running 'after' hook. Pre deploy aborted.
+  Error running 'after_pre' hook. Pre deploy aborted.
         """
         return 2
 
@@ -305,38 +305,32 @@ class BlueGreen:
 
     if not self.run_hook('before_swap', {"TAG": tag}):
         print """
-  Error running 'before' hook. Pre deploy aborted.
+  Error running 'before_swap' hook. Pre deploy aborted.
         """
         return 2
 
     if not self.add_units(apps[1], self.total_units(apps[0])):
       return 2
-
-    if not self.remove_cname(apps[0], cname):
-      print "Error removing cname of %s. Aborting..." % apps[0]
+    
+    if not self.swap(apps[0], apps[1], False):
+      print "\n  Error swaping {} and {}. Aborting...".format(apps[0], apps[1])          
       self.remove_units(apps[1], 1)
       return 2
 
-    if self.set_cname(apps[1], cname):
-      self.remove_units(apps[0])
+    self.remove_units(apps[0])
 
-      print "\n  Apps {} and {} cnames successfullly swapped!".format(apps[0], apps[1])
+    print "\n  Apps {} and {} cnames successfullly swapped!".format(apps[0], apps[1])
 
-      self.notify_newrelic(tag)
+    self.notify_newrelic(tag)
 
-      self.notify_grafana(apps[1], tag)
+    self.notify_grafana(apps[1], tag)
 
-      self.run_webhook(tag)
+    self.run_webhook(tag)
 
-      if not self.run_hook('after_swap', {"TAG": tag}):
-        print """
-  Error running 'before' hook. Pre deploy aborted.
-          """
-        return 2
-    else:
-      print "\n  Error swaping {} and {}. Aborting...".format(apps[0], apps[1])
-      self.set_cname(apps[0], cname)
-      self.remove_units(apps[1], 1)
+    if not self.run_hook('after_swap', {"TAG": tag}):
+      print """
+Error running 'after_swap' hook.
+        """
       return 2
 
     return 0

--- a/src/bluegreen.py
+++ b/src/bluegreen.py
@@ -93,9 +93,9 @@ class BlueGreen:
     conn.request("DELETE", url, None, headers)
     return conn.getresponse()
 
-  def swap(self, app1, app2):
+  def swap(self, app1, app2, force=True):
     url = "/swap"
-    body = "app1={}&app2={}&force=true&cnameOnly=true".format(app1, app2)
+    body = "app1={}&app2={}&force={}&cnameOnly=true".format(app1, app2, str(force).lower())
     return self.post(url, body)
 
   def env_set(self, app, key, value):

--- a/test/bluegreen_test.py
+++ b/test/bluegreen_test.py
@@ -442,26 +442,26 @@ class TestBlueGreen(unittest.TestCase):
     self.bg.run_hook = MagicMock(return_value=True)
     self.bg.add_units = MagicMock(return_value=True)
     self.bg.total_units = MagicMock(return_value=3)
-    self.bg.remove_cname = MagicMock(return_value=True)
-    self.bg.set_cname = MagicMock(return_value=True)
+    self.bg.swap = MagicMock(return_value=True)
     self.bg.remove_units = MagicMock()
     self.bg.notify_newrelic = MagicMock()
     self.bg.notify_grafana = MagicMock()
     self.bg.run_webhook = MagicMock()
     self.assertEqual(self.bg.deploy_swap(['test-blue', 'test-green'], ['cname-blue', 'cname-green']), 0)
+    self.bg.swap.assert_called_once_with('test-blue', 'test-green', False)
 
   def test_deploy_swap_should_return_non_zero_when_fails(self):
     self.bg.env_get = MagicMock(return_value=None)
     self.bg.run_hook = MagicMock(return_value=True)
     self.bg.add_units = MagicMock(return_value=True)
     self.bg.total_units = MagicMock(return_value=3)
-    self.bg.remove_cname = MagicMock(return_value=False)
-    self.bg.set_cname = MagicMock(return_value=True)
+    self.bg.swap = MagicMock(return_value=False)
     self.bg.remove_units = MagicMock()
     self.bg.notify_newrelic = MagicMock()
     self.bg.notify_grafana = MagicMock()
     self.bg.run_webhook = MagicMock()
     self.assertEqual(self.bg.deploy_swap(['test-blue', 'test-green'], ['cname-blue', 'cname-green']), 2)
+    self.bg.swap.assert_called_once_with('test-blue', 'test-green', False)
 
   def mock_total_units(self, values):
     calls = {'count': 0}

--- a/test/bluegreen_test.py
+++ b/test/bluegreen_test.py
@@ -113,6 +113,21 @@ class TestBlueGreen(unittest.TestCase):
                            status=200)
 
     self.assertTrue(self.bg.swap("app1", "app2"))
+    requests = httpretty.HTTPretty.latest_requests
+    self.assertEqual(len(requests), 1)
+    self.assertEqual({"app1": ["app1"], "app2": ["app2"], "force": ["true"], "cnameOnly": ["true"]}, requests[0].parsed_body)
+
+  @httpretty.activate
+  def test_swap_force_false(self):
+    httpretty.register_uri(httpretty.POST, "http://tsuruhost.com/swap",
+                           data="app1=app1&app2=app2&force=false&cnameOnly=true",
+                           status=200)
+
+    self.assertTrue(self.bg.swap("app1", "app2", False))
+    requests = httpretty.HTTPretty.latest_requests
+    self.assertEqual(len(requests), 1)
+    self.assertEqual({"app1": ["app1"], "app2": ["app2"], "force": ["false"], "cnameOnly": ["true"]}, requests[0].parsed_body)
+
 
   @httpretty.activate
   def test_env_set_return_true_when_can_set(self):


### PR DESCRIPTION
Change the deploy_swap behavior, removing logic with cname-remove + add-cname in favor of tsuru command swap cname-only.

Also refactor the swap method to accept the parameter `force`, and when used in the new deploy_swap method this will only be considered valid if the previous step, add_units works as expected...
