### PR TITLE
Fix units removal retries

### DIFF
--- a/src/bluegreen.py
+++ b/src/bluegreen.py
@@ -170,9 +170,9 @@ class BlueGreen:
         Successfully removed '%s' unit from %s""" % (process_name, app)
           return True
 
-      retries = self.retry_times if self.retry_times else 1
+      try_times = self.retry_times + 1 if self.retry_times else 1
       print """
-      Error removing '%s' units from %s in %d tries. Please, remove it manually.""" % (process_name, app, retries)
+      Error removing '%s' units from %s in %d tries. Please, remove it manually.""" % (process_name, app, try_times)
       return False
     else:
       return True

--- a/src/bluegreen.py
+++ b/src/bluegreen.py
@@ -170,8 +170,9 @@ class BlueGreen:
         Successfully removed '%s' unit from %s""" % (process_name, app)
           return True
 
+      retries = self.retry_times if self.retry_times else 1
       print """
-      Error removing '%s' units from %s in %d tries. Please, remove it manually.""" % (process_name, app, i)
+      Error removing '%s' units from %s in %d tries. Please, remove it manually.""" % (process_name, app, retries)
       return False
     else:
       return True
@@ -341,7 +342,7 @@ class BlueGreen:
       print "\n  Error swaping {} and {}. Aborting...".format(apps[0], apps[1])
       self.remove_units(apps[1], 1)
       return 2
-    
+
     print "\n  Apps {} and {} cnames successfullly swapped!".format(apps[0], apps[1])
 
     self.remove_units(apps[0])

--- a/src/bluegreen.py
+++ b/src/bluegreen.py
@@ -156,7 +156,8 @@ class BlueGreen:
         print """
     There's a running event for this app. Wait for the plugin's configured removal retries."""
 
-      for i in range(1, self.retry_times+1):
+      try_times = self.retry_times + 1
+      for i in range(1, try_times):
         response.read() # Flush buffer
         print """
     Error removing '%s' units from %s. Retrying %d...""" % (process_name, app, i)
@@ -170,12 +171,11 @@ class BlueGreen:
         Successfully removed '%s' unit from %s""" % (process_name, app)
           return True
 
-      try_times = self.retry_times + 1 if self.retry_times else 1
       print """
       Error removing '%s' units from %s in %d tries. Please, remove it manually.""" % (process_name, app, try_times)
       return False
-    else:
-      return True
+
+    return True
 
   def add_units(self, app, total_units_after_add):
     total_units = self.total_units(app)

--- a/test/bluegreen_test.py
+++ b/test/bluegreen_test.py
@@ -506,6 +506,33 @@ class TestBlueGreen(unittest.TestCase):
     self.assertEqual(self.bg.deploy_swap(['test-blue', 'test-green'], ['cname-blue', 'cname-green']), 2)
     self.bg.swap.assert_called_once_with('test-blue', 'test-green', False)
 
+  def test_swap_retries_should_return_zero_when_success(self):
+    self.config['retry_times'] = 0
+    self.bg.env_get = MagicMock(return_value=None)
+    self.bg.run_hook = MagicMock(return_value=True)
+    self.bg.add_units = MagicMock(return_value=True)
+    self.bg.total_units = MagicMock(return_value=3)
+    self.bg.swap = MagicMock(return_value=True)
+    self.bg.remove_units = MagicMock()
+    self.bg.notify_newrelic = MagicMock()
+    self.bg.notify_grafana = MagicMock()
+    self.bg.run_webhook = MagicMock()
+    self.assertEqual(self.bg.deploy_swap(['test-blue', 'test-green'], ['cname-blue', 'cname-green']), 0)
+    self.bg.swap.assert_called_once_with('test-blue', 'test-green', False)
+
+  def test_swap_retries_should_return_non_zero_when_fails(self):
+    self.bg.env_get = MagicMock(return_value=None)
+    self.bg.run_hook = MagicMock(return_value=True)
+    self.bg.add_units = MagicMock(return_value=True)
+    self.bg.total_units = MagicMock(return_value=3)
+    self.bg.swap = MagicMock(return_value=False)
+    self.bg.remove_units = MagicMock()
+    self.bg.notify_newrelic = MagicMock()
+    self.bg.notify_grafana = MagicMock()
+    self.bg.run_webhook = MagicMock()
+    self.assertEqual(self.bg.deploy_swap(['test-blue', 'test-green'], ['cname-blue', 'cname-green']), 2)
+    self.bg.swap.assert_called_once_with('test-blue', 'test-green', False)
+
   def mock_total_units(self, values):
     calls = {'count': 0}
     def total_units(*args, **kwargs):


### PR DESCRIPTION
## Description

This fixes what's mentioned in this [issue](https://github.com/emerleite/tsuru-bluegreen/issues/38) and adds tests to verify the expected behavior.

## How to test

Unit tests were added, so:

``` bash
$ make testdeps  && make test
```
or, if you wish to use Docker:
```
$ make docker-test
```
> One can also try swapping a test-app to see the timeouts and retries (don't forget to customize your .ini file as mentioned in this project's README).